### PR TITLE
[package.xml] Add links to development repo.

### DIFF
--- a/arni/package.xml
+++ b/arni/package.xml
@@ -11,6 +11,8 @@
  
    <license>BSD</license>
    <url type="website">http://wiki.ros.org/arni</url>
+   <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url>
+   <url type="repository">https://github.com/ROS-PSE/arni</url>url>
   
    <buildtool_depend>catkin</buildtool_depend>
    <run_depend>arni_msgs</run_depend>

--- a/arni_core/package.xml
+++ b/arni_core/package.xml
@@ -12,6 +12,8 @@
 
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/arni</url>
+  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url>
+  <url type="repository">https://github.com/ROS-PSE/arni</url>url>
 
   <author email="micha.wetzel@student.kit.edu">Micha Wetzel</author>
   <author email="alex.weber3@gmx.net">Alex Weber</author>

--- a/arni_countermeasure/package.xml
+++ b/arni_countermeasure/package.xml
@@ -11,7 +11,8 @@
 
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/arni</url>
-
+  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url>
+  <url type="repository">https://github.com/ROS-PSE/arni</url>url>
 
   <author email="micha.wetzel@student.kit.edu">Micha Wetzel</author>
   <author email="alex.weber3@gmx.net">Alex Weber</author>

--- a/arni_gui/package.xml
+++ b/arni_gui/package.xml
@@ -11,7 +11,8 @@
 
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/arni</url>
-
+  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url>
+  <url type="repository">https://github.com/ROS-PSE/arni</url>url>
 
   <author email="micha.wetzel@student.kit.edu">Micha Wetzel</author>
   <author email="alex.weber3@gmx.net">Alex Weber</author>

--- a/arni_msgs/package.xml
+++ b/arni_msgs/package.xml
@@ -11,7 +11,8 @@
 
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/arni</url>
-
+  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url>
+  <url type="repository">https://github.com/ROS-PSE/arni</url>url>
 
   <author email="micha.wetzel@student.kit.edu">Micha Wetzel</author>
   <author email="alex.weber3@gmx.net">Alex Weber</author>

--- a/arni_nodeinterface/package.xml
+++ b/arni_nodeinterface/package.xml
@@ -11,7 +11,8 @@
 
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/arni</url>
-
+  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url>
+  <url type="repository">https://github.com/ROS-PSE/arni</url>url>
 
   <author email="micha.wetzel@student.kit.edu">Micha Wetzel</author>
   <author email="alex.weber3@gmx.net">Alex Weber</author>

--- a/arni_rqt_detail_plugin/package.xml
+++ b/arni_rqt_detail_plugin/package.xml
@@ -11,7 +11,8 @@
 
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/arni</url>
-
+  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url>
+  <url type="repository">https://github.com/ROS-PSE/arni</url>url>
 
   <author email="micha.wetzel@student.kit.edu">Micha Wetzel</author>
   <author email="alex.weber3@gmx.net">Alex Weber</author>

--- a/arni_rqt_overview_plugin/package.xml
+++ b/arni_rqt_overview_plugin/package.xml
@@ -11,7 +11,8 @@
 
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/arni</url>
-
+  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url>
+  <url type="repository">https://github.com/ROS-PSE/arni</url>url>
 
   <author email="micha.wetzel@student.kit.edu">Micha Wetzel</author>
   <author email="alex.weber3@gmx.net">Alex Weber</author>


### PR DESCRIPTION
Other than package.xml being an "official" description for a package, having these links are very helpful from ROS wiki page.