### PR TITLE
Issue #19  fix to show context menu on arni_rqt_detail_plugin 

### DIFF
--- a/arni_rqt_detail_plugin/src/arni_rqt_detail_plugin/tree_widget.py
+++ b/arni_rqt_detail_plugin/src/arni_rqt_detail_plugin/tree_widget.py
@@ -17,7 +17,9 @@ try:  # Qt4 vs Qt5
   from python_qt_binding.QtGui import *
 except ImportError:
   from python_qt_binding.QtCore import QSortFilterProxyModel
-  from python_qt_binding.QtWidgets import QWidget
+  from python_qt_binding.QtWidgets import *
+
+
 from python_qt_binding.QtGui import QAction
 from python_qt_binding.QtCore import QPoint
 


### PR DESCRIPTION
Related to #19, this fix just imports all of the modules under python_qt_bindings.QtWidgets instead of the QWidget.  The context menu on the detail plugin does show after this change.