### PR TITLE
[fix] missing dependency. Cyclic dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  # direct pushes to protected branches are not supported
+  pull_request:
+  push:
+  workflow_dispatch:
+
+jobs:
+  i_ci:
+    name: ubuntu_bionic (${{ matrix.ros_repo }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ros_distro: [ melodic, noetic ]
+        ros_repo: [ main, testing ]
+
+    env:
+      CCACHE_DIR: "${{ github.workspace }}/.ccache"
+      CATKIN_LINT: "true"
+      CATKIN_LINT_ARGS: --ignore launch_depend
+
+    steps:
+      - name: Fetch repository
+        uses: actions/checkout@v2
+
+      - name: ccache cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          # we always want the ccache cache to be persisted, as we cannot easily
+          # determine whether dependencies have changed, and ccache will manage
+          # updating the cache for us. Adding 'run_id' to the key will force an
+          # upload at the end of the job.
+          key: ccache-${{ matrix.ros_distro }}-${{ matrix.ros_repo }}-${{github.run_id}}
+          restore-keys: |
+            ccache-${{ matrix.ros_distro }}-${{ matrix.ros_repo }}
+
+      - name: Run industrial_ci
+        uses: ros-industrial/industrial_ci@master
+        env:
+          ROS_DISTRO: ${{ matrix.ros_distro }}
+          ROS_REPO: ${{ matrix.ros_repo }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        ros_distro: [ melodic, noetic ]
+        ros_distro: [ melodic ]
         ros_repo: [ main, testing ]
 
     env:

--- a/arni/package.xml
+++ b/arni/package.xml
@@ -11,20 +11,20 @@
  
    <license>BSD</license>
    <url type="website">http://wiki.ros.org/arni</url>
-   <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url>
-   <url type="repository">https://github.com/ROS-PSE/arni</url>url>
+   <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url&gt;
+   <url type="repository">https://github.com/ROS-PSE/arni</url>url&gt;
   
    <buildtool_depend>catkin</buildtool_depend>
-   <run_depend>arni_msgs</run_depend>
    <run_depend>arni_core</run_depend>
    <run_depend>arni_countermeasure</run_depend>
-   <run_depend>arni_processing</run_depend>
-   <run_depend>arni_nodeinterface</run_depend>
    <run_depend>arni_gui</run_depend>
+   <run_depend>arni_msgs</run_depend>
+   <run_depend>arni_nodeinterface</run_depend>
+   <run_depend>arni_processing</run_depend>
    <run_depend>arni_rqt_detail_plugin</run_depend>
    <run_depend>arni_rqt_overview_plugin</run_depend>
 
 	 <export>
-   		<metapackage />
+   		<metapackage/>
 	 </export>
 </package>

--- a/arni_core/CMakeLists.txt
+++ b/arni_core/CMakeLists.txt
@@ -13,7 +13,7 @@ install(DIRECTORY launch/
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
 )
 
-install(FILES test/constraint_node_stop.yaml test/iceland_constraint.yaml test/iceland_specification.yaml test/test_1_3x3_specification.yaml test/test_1_constraint.yaml test/test_1_specification.yaml test/test_2_constraint.yaml test/test_2_specification.yaml test/test_3_constraint.yaml test/test_3_specification.yaml test/test_4_constraint.yaml test/test_4_specification.yaml test/test_5_constraint.yaml test/test_5_specification.yaml test/test_cases entwurf test/test_node_shutdown.test
+install(FILES test/constraint_node_stop.yaml test/iceland_constraint.yaml test/iceland_specification.yaml test/test_1_3x3_specification.yaml test/test_1_constraint.yaml test/test_1_specification.yaml test/test_2_constraint.yaml test/test_2_specification.yaml test/test_3_constraint.yaml test/test_3_specification.yaml test/test_4_constraint.yaml test/test_4_specification.yaml test/test_5_constraint.yaml test/test_5_specification.yaml test/test_node_shutdown.test
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/test
 )
 catkin_install_python(PROGRAMS tutorial/tutorial_listening_mole tutorial/tutorial_publishing_owl tutorial/tutorial_publishing_snake test/predefined_publisher.py test/test_node_shutdown.py test/predefined_subscriber.py

--- a/arni_core/CMakeLists.txt
+++ b/arni_core/CMakeLists.txt
@@ -1,139 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(arni_core)
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
 find_package(catkin REQUIRED)
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
 catkin_python_setup()
 
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependencies might have been
-##     pulled in transitively but can be declared for certainty nonetheless:
-##     * add a build_depend tag for "message_generation"
-##     * add a run_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs  # Or other packages containing msgs
-# )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if you package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
-catkin_package(
-#  INCLUDE_DIRS include
-#  LIBRARIES arni_core
-#  CATKIN_DEPENDS other_catkin_pkg
-#  DEPENDS system_lib
-)
-
-###########
-## Build ##
-###########
-
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-# include_directories(include)
-
-## Declare a cpp library
-# add_library(arni_core
-#   src/${PROJECT_NAME}/arni_core.cpp
-# )
-
-## Declare a cpp executable
-# add_executable(arni_core_node src/arni_core_node.cpp)
-
-## Add cmake target dependencies of the executable/library
-## as an example, message headers may need to be generated before nodes
-# add_dependencies(arni_core_node arni_core_generate_messages_cpp)
-
-## Specify libraries to link a library or executable target against
-# target_link_libraries(arni_core_node
-#   ${catkin_LIBRARIES}
-# )
-
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables and/or libraries for installation
-# install(TARGETS arni_core arni_core_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
+catkin_package()
 
 #catkin_install_python(PROGRAMS scripts/   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
@@ -141,22 +13,9 @@ install(DIRECTORY launch/
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
 )
 
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_arni_core.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)
+install(FILES test/constraint_node_stop.yaml test/iceland_constraint.yaml test/iceland_specification.yaml test/test_1_3x3_specification.yaml test/test_1_constraint.yaml test/test_1_specification.yaml test/test_2_constraint.yaml test/test_2_specification.yaml test/test_3_constraint.yaml test/test_3_specification.yaml test/test_4_constraint.yaml test/test_4_specification.yaml test/test_5_constraint.yaml test/test_5_specification.yaml test/test_cases entwurf test/test_node_shutdown.test
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/test
+)
+catkin_install_python(PROGRAMS tutorial/tutorial_listening_mole tutorial/tutorial_publishing_owl tutorial/tutorial_publishing_snake test/predefined_publisher.py test/test_node_shutdown.py test/predefined_subscriber.py
+                      DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/arni_core/package.xml
+++ b/arni_core/package.xml
@@ -28,7 +28,8 @@
   <build_depend>rosnode</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
-  <run_depend>arni_countermeasure</run_depend>
+  <!--  <run_depend>arni_countermeasure</run_depend>
+        This pkg is indeed referenced, but it causes cyclic dependency (Catkin terminates with failure) so for now commented out so that Catkin doesn't fail.  -->
   <run_depend>arni_msgs</run_depend>
   <run_depend>arni_nodeinterface</run_depend>
   <run_depend>arni_processing</run_depend>

--- a/arni_core/package.xml
+++ b/arni_core/package.xml
@@ -12,21 +12,31 @@
 
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/arni</url>
-  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url>
-  <url type="repository">https://github.com/ROS-PSE/arni</url>url>
+  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url&gt;
+  <url type="repository">https://github.com/ROS-PSE/arni</url>url&gt;
 
   <author email="micha.wetzel@student.kit.edu">Micha Wetzel</author>
   <author email="alex.weber3@gmx.net">Alex Weber</author>
   <author email="matthias.klatte@go4more.de">Matthias Klatte</author>
   <author email="sebastian.kneipp@gmx.net">Sebastian Kneipp</author>
   <author email="matthiashadlich@yahoo.de">Matthias Hadlich</author>
-
-
-  <build_depend>arni_msgs</build_depend>
-  <run_depend>arni_msgs</run_depend>
   <buildtool_depend>catkin</buildtool_depend>
 
-
-  <export>
-  </export>
+  <build_depend>arni_msgs</build_depend>
+  <build_depend>rosgraph</build_depend>
+  <build_depend>rosgraph_msgs</build_depend>
+  <build_depend>rosnode</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <run_depend>arni_countermeasure</run_depend>
+  <run_depend>arni_msgs</run_depend>
+  <run_depend>arni_nodeinterface</run_depend>
+  <run_depend>arni_processing</run_depend>
+  <run_depend>rosgraph</run_depend>
+  <run_depend>rosgraph_msgs</run_depend>
+  <run_depend>rosnode</run_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <test_depend>rostest</test_depend>
+  <test_depend>rosunit</test_depend>
 </package>

--- a/arni_countermeasure/CMakeLists.txt
+++ b/arni_countermeasure/CMakeLists.txt
@@ -1,161 +1,26 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(arni_countermeasure)
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
 find_package(catkin REQUIRED)
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
 catkin_python_setup()
 
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependencies might have been
-##     pulled in transitively but can be declared for certainty nonetheless:
-##     * add a build_depend tag for "message_generation"
-##     * add a run_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs  # Or other packages containing msgs
-# )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if you package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
-catkin_package(
-#  INCLUDE_DIRS include
-#  LIBRARIES arni_countermeasure
-#  CATKIN_DEPENDS other_catkin_pkg
-#  DEPENDS system_lib
+catkin_package()
+install(FILES src/arni_countermeasure/changes.md
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/src/arni_countermeasure
+)
+install(FILES tests/test_parsing_constraint.test tests/test_reaction.test tests/test_scenario.test tests/test_storage.test
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/tests
+)
+install(FILES tests/config/default.yaml
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/tests/config
+)
+install(FILES tests/constraints/john_high_publish.yaml tests/constraints/test_scenario.yaml
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/tests/constraints
 )
 
-###########
-## Build ##
-###########
-
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-# include_directories(include)
-
-## Declare a cpp library
-# add_library(arni_countermeasure
-#   src/${PROJECT_NAME}/arni_countermeasure.cpp
-# )
-
-## Declare a cpp executable
-# add_executable(arni_countermeasure_node src/arni_countermeasure_node.cpp)
-
-## Add cmake target dependencies of the executable/library
-## as an example, message headers may need to be generated before nodes
-# add_dependencies(arni_countermeasure_node arni_countermeasure_generate_messages_cpp)
-
-## Specify libraries to link a library or executable target against
-# target_link_libraries(arni_countermeasure_node
-#   ${catkin_LIBRARIES}
-# )
-
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables and/or libraries for installation
-# install(TARGETS arni_countermeasure arni_countermeasure_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-catkin_install_python(PROGRAMS scripts/arni_countermeasure 
-	DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+catkin_install_python(PROGRAMS scripts/arni_countermeasure tests/increased_clock.py tests/test_parsing_constraint.py tests/test_reaction.py tests/test_scenario.py tests/test_storage.py 
+	DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
  
 
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_arni_countermeasure.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)

--- a/arni_countermeasure/package.xml
+++ b/arni_countermeasure/package.xml
@@ -11,22 +11,32 @@
 
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/arni</url>
-  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url>
-  <url type="repository">https://github.com/ROS-PSE/arni</url>url>
+  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url&gt;
+  <url type="repository">https://github.com/ROS-PSE/arni</url>url&gt;
 
   <author email="micha.wetzel@student.kit.edu">Micha Wetzel</author>
   <author email="alex.weber3@gmx.net">Alex Weber</author>
   <author email="matthias.klatte@go4more.de">Matthias Klatte</author>
   <author email="sebastian.kneipp@gmx.net">Sebastian Kneipp</author>
   <author email="matthiashadlich@yahoo.de">Matthias Hadlich</author>
-
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>arni_core</build_depend>
 
   <build_depend>arni_msgs</build_depend>
-  <build_depend>arni_core</build_depend>
-  <run_depend>arni_msgs</run_depend>
+  <build_depend>rosbag</build_depend>
+  <build_depend>rosgraph_msgs</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>rostest</build_depend>
+  <build_depend>rosunit</build_depend>
+  <build_depend>std_srvs</build_depend>
   <run_depend>arni_core</run_depend>
-  <buildtool_depend>catkin</buildtool_depend>
-
+  <run_depend>arni_msgs</run_depend>
+  <run_depend>rosbag</run_depend>
+  <run_depend>rosgraph_msgs</run_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>rostest</run_depend>
+  <run_depend>rosunit</run_depend>
+  <run_depend>std_srvs</run_depend>
 
   <export>
   </export>

--- a/arni_gui/CMakeLists.txt
+++ b/arni_gui/CMakeLists.txt
@@ -1,163 +1,34 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(arni_gui)
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
 find_package(catkin REQUIRED)
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
 catkin_python_setup()
 
-
-
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependencies might have been
-##     pulled in transitively but can be declared for certainty nonetheless:
-##     * add a build_depend tag for "message_generation"
-##     * add a run_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs  # Or other packages containing msgs
-# )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if you package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-#  INCLUDE_DIRS include
 #  LIBRARIES arni_countermeasure
-#  CATKIN_DEPENDS other_catkin_pkg
-#  DEPENDS system_lib
 )
 
-###########
-## Build ##
-###########
-
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-# include_directories(include)
-
-## Declare a cpp library
 # add_library(arni_countermeasure
 #   src/${PROJECT_NAME}/arni_countermeasure.cpp
-# )
 
-## Declare a cpp executable
 # add_executable(arni_countermeasure_node src/arni_countermeasure_node.cpp)
 
-## Add cmake target dependencies of the executable/library
-## as an example, message headers may need to be generated before nodes
 # add_dependencies(arni_countermeasure_node arni_countermeasure_generate_messages_cpp)
 
-## Specify libraries to link a library or executable target against
 # target_link_libraries(arni_countermeasure_node
-#   ${catkin_LIBRARIES}
-# )
 
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables and/or libraries for installation
 # install(TARGETS arni_countermeasure arni_countermeasure_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
 
 install(DIRECTORY translations/
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/translations)
  
 
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
 # catkin_add_gtest(${PROJECT_NAME}-test test/test_arni_countermeasure.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
 
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)
+install(FILES translations.pro
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+catkin_install_python(PROGRAMS scripts/test_main.py scripts/tests/ros_model_tests.py
+                      DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/arni_gui/package.xml
+++ b/arni_gui/package.xml
@@ -11,8 +11,8 @@
 
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/arni</url>
-  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url>
-  <url type="repository">https://github.com/ROS-PSE/arni</url>url>
+  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url&gt;
+  <url type="repository">https://github.com/ROS-PSE/arni</url>url&gt;
 
   <author email="micha.wetzel@student.kit.edu">Micha Wetzel</author>
   <author email="alex.weber3@gmx.net">Alex Weber</author>
@@ -20,20 +20,27 @@
   <author email="sebastian.kneipp@gmx.net">Sebastian Kneipp</author>
   <author email="matthiashadlich@yahoo.de">Matthias Hadlich</author>
 
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>arni_core</build_depend>
 
   <build_depend>arni_msgs</build_depend>
-  <build_depend>arni_core</build_depend>
+  <build_depend>genpy</build_depend>
+  <build_depend>python_qt_binding</build_depend>
+  <build_depend>rosgraph</build_depend>
   <build_depend>rosgraph_msgs</build_depend>
   <build_depend>rospy</build_depend>
+  <build_depend>rqt_graph</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <run_depend>arni_core</run_depend>
   
   <run_depend>arni_msgs</run_depend>
-  <run_depend>arni_core</run_depend>
+  <run_depend>genpy</run_depend>
+  <run_depend>python-enum</run_depend>
+  <run_depend>python-rospkg</run_depend>
+  <run_depend>python_qt_binding</run_depend>
+  <run_depend>rosgraph</run_depend>
   <run_depend>rosgraph_msgs</run_depend>
   <run_depend>rospy</run_depend>
-
-  <buildtool_depend>catkin</buildtool_depend>
-
-  <export>
-
-  </export>
+  <run_depend>rqt_graph</run_depend>
+  <run_depend>std_msgs</run_depend>
 </package>

--- a/arni_gui/package.xml
+++ b/arni_gui/package.xml
@@ -35,7 +35,7 @@
   
   <run_depend>arni_msgs</run_depend>
   <run_depend>genpy</run_depend>
-  <run_depend>python-enum</run_depend>
+  <run_depend>python-enum34</run_depend>
   <run_depend>python-rospkg</run_depend>
   <run_depend>python_qt_binding</run_depend>
   <run_depend>rosgraph</run_depend>

--- a/arni_msgs/CMakeLists.txt
+++ b/arni_msgs/CMakeLists.txt
@@ -1,167 +1,53 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(arni_msgs)
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
-    std_msgs
     message_generation
-    rosgraph_msgs)
+    rosgraph_msgs
+    std_msgs
+)
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
-
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependencies might have been
-##     pulled in transitively but can be declared for certainty nonetheless:
-##     * add a build_depend tag for "message_generation"
-##     * add a run_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
 add_message_files(
     FILES
     HostStatistics.msg
-    NodeStatistics.msg
-    RatedStatisticsEntity.msg
-    RatedStatistics.msg
-    MasterApiEntity.msg
     MasterApi.msg
+    MasterApiEntity.msg
+    NodeStatistics.msg
+    RatedStatistics.msg
+    RatedStatisticsEntity.msg
 )
 
-## Generate services in the 'srv' folder
 add_service_files(
     FILES
     NodeReaction.srv
     StatisticHistory.srv
 )
 
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
 generate_messages(
   DEPENDENCIES
-  std_msgs  # Or other packages containing msgs
-  rosgraph_msgs
+  # Or other packages containing msgs
+  rosgraph_msgs  std_msgs
 
 )
 
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if you package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES arni_msg
 #  CATKIN_DEPENDS other_catkin_pkg
 #  DEPENDS system_lib
-    CATKIN_DEPENDS message_runtime
+    CATKIN_DEPENDS message_runtime rosgraph_msgs
 )
 
-###########
-## Build ##
-###########
-
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-# include_directories(include)
-
-## Declare a cpp library
 # add_library(arni_msg
 #   src/${PROJECT_NAME}/arni_msg.cpp
-# )
 
-## Declare a cpp executable
 # add_executable(arni_msg_node src/arni_msg_node.cpp)
 
-## Add cmake target dependencies of the executable/library
-## as an example, message headers may need to be generated before nodes
 # add_dependencies(arni_msg_node arni_msg_generate_messages_cpp)
 
-## Specify libraries to link a library or executable target against
 # target_link_libraries(arni_msg_node
-#   ${catkin_LIBRARIES}
-# )
 
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables and/or libraries for installation
 # install(TARGETS arni_msg arni_msg_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
 
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
 # catkin_add_gtest(${PROJECT_NAME}-test test/test_arni_msg.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
 
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)

--- a/arni_msgs/msg/MasterApi.msg
+++ b/arni_msgs/msg/MasterApi.msg
@@ -1,6 +1,6 @@
 # publisher
-MasterApiEntity[] pubs
+arni_msgs/MasterApiEntity[] pubs
 # subscriber
-MasterApiEntity[] subs
+arni_msgs/MasterApiEntity[] subs
 # services
-MasterApiEntity[] srvs
+arni_msgs/MasterApiEntity[] srvs

--- a/arni_msgs/msg/RatedStatistics.msg
+++ b/arni_msgs/msg/RatedStatistics.msg
@@ -2,11 +2,11 @@
 string seuid
 
 # only used if seuid is a node. is the host ip the node runs on.
-string host  
+string host
 
 # the rated statistics apply to statistics from this time window
 time window_start
 time window_stop
 
 # an array of rated entities
-RatedStatisticsEntity[] rated_statistics_entity
+arni_msgs/RatedStatisticsEntity[] rated_statistics_entity

--- a/arni_msgs/package.xml
+++ b/arni_msgs/package.xml
@@ -11,22 +11,18 @@
 
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/arni</url>
-  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url>
-  <url type="repository">https://github.com/ROS-PSE/arni</url>url>
+  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url&gt;
+  <url type="repository">https://github.com/ROS-PSE/arni</url>url&gt;
 
   <author email="micha.wetzel@student.kit.edu">Micha Wetzel</author>
   <author email="alex.weber3@gmx.net">Alex Weber</author>
   <author email="matthias.klatte@go4more.de">Matthias Klatte</author>
   <author email="sebastian.kneipp@gmx.net">Sebastian Kneipp</author>
   <author email="matthiashadlich@yahoo.de">Matthias Hadlich</author>
+  <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>message_generation</build_depend>
   <build_depend>rosgraph_msgs</build_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>rosgraph_msgs</run_depend>
-  <buildtool_depend>catkin</buildtool_depend>
-
-
-  <export>
-  </export>
 </package>

--- a/arni_msgs/srv/StatisticHistory.srv
+++ b/arni_msgs/srv/StatisticHistory.srv
@@ -4,11 +4,11 @@ time timestamp
 # each statistic has its own rated statistic. 
 # timestamps can be found at the time windows of each statistic
 
-HostStatistics[] host_statistics
-RatedStatistics[] rated_host_statistics
+arni_msgs/HostStatistics[] host_statistics
+arni_msgs/RatedStatistics[] rated_host_statistics
 
-NodeStatistics[] node_statistics
-RatedStatistics[] rated_node_statistics
+arni_msgs/NodeStatistics[] node_statistics
+arni_msgs/RatedStatistics[] rated_node_statistics
 
 rosgraph_msgs/TopicStatistics[] topic_statistics
-RatedStatistics[] rated_topic_statistics
+arni_msgs/RatedStatistics[] rated_topic_statistics

--- a/arni_nodeinterface/CMakeLists.txt
+++ b/arni_nodeinterface/CMakeLists.txt
@@ -1,160 +1,30 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(arni_nodeinterface)
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
 find_package(catkin REQUIRED)
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
 catkin_python_setup()
 
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependencies might have been
-##     pulled in transitively but can be declared for certainty nonetheless:
-##     * add a build_depend tag for "message_generation"
-##     * add a run_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs  # Or other packages containing msgs
-# )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if you package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-#  INCLUDE_DIRS include
 #  LIBRARIES arni_countermeasure
-#  CATKIN_DEPENDS other_catkin_pkg
-#  DEPENDS system_lib
+)
+install(FILES test/test_service.test test/test_statistical_calc.test
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/test
 )
 
-###########
-## Build ##
-###########
-
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-# include_directories(include)
-
-## Declare a cpp library
 # add_library(arni_countermeasure
 #   src/${PROJECT_NAME}/arni_countermeasure.cpp
-# )
 
-## Declare a cpp executable
 # add_executable(arni_countermeasure_node src/arni_countermeasure_node.cpp)
 
-## Add cmake target dependencies of the executable/library
-## as an example, message headers may need to be generated before nodes
 # add_dependencies(arni_countermeasure_node arni_countermeasure_generate_messages_cpp)
 
-## Specify libraries to link a library or executable target against
 # target_link_libraries(arni_countermeasure_node
-#   ${catkin_LIBRARIES}
-# )
 
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables and/or libraries for installation
 # install(TARGETS arni_countermeasure arni_countermeasure_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
 
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-catkin_install_python(PROGRAMS scripts/arni_nodeinterface DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+catkin_install_python(PROGRAMS scripts/arni_nodeinterface test/test_service.py test/test_statistical_calc.py test/writer.py DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
  
 
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
 # catkin_add_gtest(${PROJECT_NAME}-test test/test_arni_countermeasure.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
 
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)

--- a/arni_nodeinterface/package.xml
+++ b/arni_nodeinterface/package.xml
@@ -11,8 +11,8 @@
 
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/arni</url>
-  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url>
-  <url type="repository">https://github.com/ROS-PSE/arni</url>url>
+  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url&gt;
+  <url type="repository">https://github.com/ROS-PSE/arni</url>url&gt;
 
   <author email="micha.wetzel@student.kit.edu">Micha Wetzel</author>
   <author email="alex.weber3@gmx.net">Alex Weber</author>
@@ -21,17 +21,19 @@
   <author email="matthiashadlich@yahoo.de">Matthias Hadlich</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>arni_msgs</build_depend>
+  <build_depend>rosgraph_msgs</build_depend>
+  <build_depend>roslaunch</build_depend>
+  <build_depend>rosnode</build_depend>
 
   <build_depend>rospy</build_depend>
   <build_depend>rostest</build_depend>
-  <build_depend>arni_msgs</build_depend>
-  <build_depend>rosgraph_msgs</build_depend>
+  <run_depend>arni_msgs</run_depend>
+  <run_depend>python-psutil</run_depend>
+  <run_depend>rosgraph_msgs</run_depend>
+  <run_depend>roslaunch</run_depend>
+  <run_depend>rosnode</run_depend>
 
   <run_depend>rospy</run_depend>
-  <run_depend>arni_msgs</run_depend>
-  <run_depend>rosgraph_msgs</run_depend>
-
-
-  <export>
-  </export>
+  <test_depend>rosunit</test_depend>
 </package>

--- a/arni_nodeinterface/package.xml
+++ b/arni_nodeinterface/package.xml
@@ -21,6 +21,7 @@
   <author email="matthiashadlich@yahoo.de">Matthias Hadlich</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+<!--  <build_depend>arni_countermeasure</build_depend> This is right, but causes circular depepdency -->
   <build_depend>arni_msgs</build_depend>
   <build_depend>rosgraph_msgs</build_depend>
   <build_depend>roslaunch</build_depend>

--- a/arni_processing/CMakeLists.txt
+++ b/arni_processing/CMakeLists.txt
@@ -1,158 +1,37 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(arni_processing)
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
 find_package(catkin REQUIRED)
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
 catkin_python_setup()
 
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependencies might have been
-##     pulled in transitively but can be declared for certainty nonetheless:
-##     * add a build_depend tag for "message_generation"
-##     * add a run_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs  # Or other packages containing msgs
-# )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if you package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-#  INCLUDE_DIRS include
 #  LIBRARIES arni_countermeasure
-#  CATKIN_DEPENDS other_catkin_pkg
-#  DEPENDS system_lib
+)
+install(FILES resources/testconfig.yaml
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/resources
+)
+install(FILES test/test_loading_specifications.test test/test_rating_data.test test/test_seuid.test
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/test
+)
+install(FILES test/mockdata/keksconf.yaml test/mockdata/mock_host.yaml test/mockdata/mock_host_spec.yaml test/mockdata/mock_host_spec2.yaml
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/test/mockdata
 )
 
-###########
-## Build ##
-###########
-
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-# include_directories(include)
-
-## Declare a cpp library
 # add_library(arni_countermeasure
 #   src/${PROJECT_NAME}/arni_countermeasure.cpp
-# )
 
-## Declare a cpp executable
 # add_executable(arni_countermeasure_node src/arni_countermeasure_node.cpp)
 
-## Add cmake target dependencies of the executable/library
-## as an example, message headers may need to be generated before nodes
 # add_dependencies(arni_countermeasure_node arni_countermeasure_generate_messages_cpp)
 
-## Specify libraries to link a library or executable target against
 # target_link_libraries(arni_countermeasure_node
-#   ${catkin_LIBRARIES}
-# )
 
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables and/or libraries for installation
 # install(TARGETS arni_countermeasure arni_countermeasure_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
 
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
+catkin_install_python(PROGRAMS scripts/arni_processing test/test_loading_specifications.py test/test_rating_data.py test/test_seuid.py
+                      DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-catkin_install_python(PROGRAMS scripts/arni_processing DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
 # catkin_add_gtest(${PROJECT_NAME}-test test/test_arni_countermeasure.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
 
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)

--- a/arni_processing/package.xml
+++ b/arni_processing/package.xml
@@ -12,7 +12,6 @@
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/arni</url>
 
-
   <author email="micha.wetzel@student.kit.edu">Micha Wetzel</author>
   <author email="alex.weber3@gmx.net">Alex Weber</author>
   <author email="matthias.klatte@go4more.de">Matthias Klatte</author>
@@ -20,13 +19,22 @@
   <author email="matthiashadlich@yahoo.de">Matthias Hadlich</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>arni_msgs</build_depend>
+  <build_depend>rosgraph</build_depend>
+  <build_depend>rosgraph_msgs</build_depend>
 
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>arni_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
+  <run_depend>arni_msgs</run_depend>
+  <run_depend>rosgraph</run_depend>
+  <run_depend>rosgraph_msgs</run_depend>
 
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>
-  <run_depend>arni_msgs</run_depend>
+  <run_depend>std_srvs</run_depend>
+  <test_depend>rosparam</test_depend>
+  <test_depend>rostest</test_depend>
+  <test_depend>rosunit</test_depend>
 
 </package>

--- a/arni_rqt_detail_plugin/CMakeLists.txt
+++ b/arni_rqt_detail_plugin/CMakeLists.txt
@@ -23,7 +23,7 @@ install(PROGRAMS scripts/arni_rqt_detail_plugin
 install(FILES resources/SelectionWidget.ui resources/TreeWidget.ui
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/resources
 )
-install(FILES resources/graphics/Ampel Zeichen.png resources/graphics/block_green.png resources/graphics/block_green_old.png resources/graphics/block_grey.png resources/graphics/block_orange.png resources/graphics/block_red.png resources/graphics/block_red_old.png resources/graphics/collaps.png resources/graphics/expand.png resources/graphics/light_green.png resources/graphics/light_grey.png resources/graphics/light_orange.png resources/graphics/light_red.png resources/graphics/minus.png resources/graphics/plus.png
+install(FILES "resources/graphics/Ampel Zeichen.png" resources/graphics/block_green.png resources/graphics/block_green_old.png resources/graphics/block_grey.png resources/graphics/block_orange.png resources/graphics/block_red.png resources/graphics/block_red_old.png resources/graphics/collaps.png resources/graphics/expand.png resources/graphics/light_green.png resources/graphics/light_grey.png resources/graphics/light_orange.png resources/graphics/light_red.png resources/graphics/minus.png resources/graphics/plus.png
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/resources/graphics
 )
 

--- a/arni_rqt_detail_plugin/CMakeLists.txt
+++ b/arni_rqt_detail_plugin/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(arni_rqt_detail_plugin)
 
-
 find_package(catkin REQUIRED COMPONENTS qt_gui)
+catkin_python_setup()
 #	COMPONENTS
 #	rospy
 #  	rqt_gui
@@ -10,15 +10,22 @@ find_package(catkin REQUIRED COMPONENTS qt_gui)
 #)
 
 catkin_package()
-catkin_python_setup()
 
 install(FILES plugin.xml
-	DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
 install(DIRECTORY resources
-	DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
 install(PROGRAMS scripts/arni_rqt_detail_plugin
-	DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-
+        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+install(FILES resources/SelectionWidget.ui resources/TreeWidget.ui
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/resources
+)
+install(FILES resources/graphics/Ampel Zeichen.png resources/graphics/block_green.png resources/graphics/block_green_old.png resources/graphics/block_grey.png resources/graphics/block_orange.png resources/graphics/block_red.png resources/graphics/block_red_old.png resources/graphics/collaps.png resources/graphics/expand.png resources/graphics/light_green.png resources/graphics/light_grey.png resources/graphics/light_orange.png resources/graphics/light_red.png resources/graphics/minus.png resources/graphics/plus.png
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/resources/graphics
+)
 
 #catkin_package(
   #INCLUDE_DIRS include
@@ -27,10 +34,10 @@ install(PROGRAMS scripts/arni_rqt_detail_plugin
  # DEPENDS system_lib
 #)
 
-catkin_install_python(PROGRAMS scripts/arni_rqt_detail_plugin DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-
+catkin_install_python(PROGRAMS scripts/arni_rqt_detail_plugin
+                      DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 #include_directories(
- # ${catkin_INCLUDE_DIRS}
-#)
+ #)
 

--- a/arni_rqt_detail_plugin/package.xml
+++ b/arni_rqt_detail_plugin/package.xml
@@ -11,8 +11,8 @@
 
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/arni</url>
-  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url>
-  <url type="repository">https://github.com/ROS-PSE/arni</url>url>
+  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url&gt;
+  <url type="repository">https://github.com/ROS-PSE/arni</url>url&gt;
 
   <author email="micha.wetzel@student.kit.edu">Micha Wetzel</author>
   <author email="alex.weber3@gmx.net">Alex Weber</author>
@@ -20,18 +20,22 @@
   <author email="sebastian.kneipp@gmx.net">Sebastian Kneipp</author>
   <author email="matthiashadlich@yahoo.de">Matthias Hadlich</author>
 
-
   <buildtool_depend>catkin</buildtool_depend>
- 
-  <run_depend>rospy</run_depend>
-  <run_depend>rqt_gui</run_depend>
-  <run_depend>rqt_gui_py</run_depend>
-  <run_depend>arni_gui</run_depend>
+  <build_depend>arni_gui</build_depend>
+  <build_depend>python_qt_binding</build_depend>
 
   <build_depend>rospy</build_depend>
   <build_depend>rqt_gui</build_depend>
   <build_depend>rqt_gui_py</build_depend>
-  <build_depend>arni_gui</build_depend>
+  <run_depend>arni_gui</run_depend>
+  <run_depend>python-argparse</run_depend>
+  <run_depend>python-rospkg</run_depend>
+  <run_depend>python-yaml</run_depend>
+  <run_depend>python_qt_binding</run_depend>
+ 
+  <run_depend>rospy</run_depend>
+  <run_depend>rqt_gui</run_depend>
+  <run_depend>rqt_gui_py</run_depend>
 
   <export>    	
     <rqt_gui plugin="${prefix}/plugin.xml"/>

--- a/arni_rqt_overview_plugin/CMakeLists.txt
+++ b/arni_rqt_overview_plugin/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(arni_rqt_overview_plugin)
 
-
 find_package(catkin REQUIRED COMPONENTS qt_gui)
+catkin_python_setup()
 #	COMPONENTS
 #	rospy
 #  	rqt_gui
@@ -10,28 +10,35 @@ find_package(catkin REQUIRED COMPONENTS qt_gui)
 #)
 
 catkin_package()
-catkin_python_setup()
 
 install(FILES plugin.xml
-	DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
 install(DIRECTORY resources
-	DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
 install(PROGRAMS scripts/arni_rqt_overview_plugin
-	DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-
+        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+install(FILES resources/OverviewWidget.ui
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/resources
+)
+install(FILES resources/graphics/Ampel Zeichen grey.png resources/graphics/Ampel Zeichen.png resources/graphics/block_green.png resources/graphics/block_red.png resources/graphics/light_green.png resources/graphics/light_orange.png resources/graphics/light_red.png resources/graphics/minus.png resources/graphics/plus.png
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/resources/graphics
+)
+install(FILES src/arni_rqt_overview_plugin/test
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/src/arni_rqt_overview_plugin
+)
 
 #catkin_package(
-#  INCLUDE_DIRS include
 #  LIBRARIES rqt_overview
 #  CATKIN_DEPENDS rospy rqt_gui rqt_gui_py
-#  DEPENDS system_lib
 #)
 
-catkin_install_python(PROGRAMS scripts/arni_rqt_overview_plugin DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-
+catkin_install_python(PROGRAMS scripts/arni_rqt_overview_plugin src/arni_rqt_overview_plugin/arni_gui_overview.py
+                      DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 #include_directories(
- # ${catkin_INCLUDE_DIRS}
-#)
-
+ #)
 

--- a/arni_rqt_overview_plugin/package.xml
+++ b/arni_rqt_overview_plugin/package.xml
@@ -11,8 +11,8 @@
 
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/arni</url>
-  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url>
-  <url type="repository">https://github.com/ROS-PSE/arni</url>url>
+  <url type="bugtracker">https://github.com/ROS-PSE/arni/issues</url>url&gt;
+  <url type="repository">https://github.com/ROS-PSE/arni</url>url&gt;
 
   <author email="micha.wetzel@student.kit.edu">Micha Wetzel</author>
   <author email="alex.weber3@gmx.net">Alex Weber</author>
@@ -20,18 +20,21 @@
   <author email="sebastian.kneipp@gmx.net">Sebastian Kneipp</author>
   <author email="matthiashadlich@yahoo.de">Matthias Hadlich</author>
 
-
   <buildtool_depend>catkin</buildtool_depend>
- 
-  <run_depend>rospy</run_depend>
-  <run_depend>rqt_gui</run_depend>
-  <run_depend>rqt_gui_py</run_depend>
-  <run_depend>arni_gui</run_depend>
+  <build_depend>arni_gui</build_depend>
+  <build_depend>python_qt_binding</build_depend>
 
   <build_depend>rospy</build_depend>
   <build_depend>rqt_gui</build_depend>
   <build_depend>rqt_gui_py</build_depend>
-  <build_depend>arni_gui</build_depend>
+  <run_depend>arni_gui</run_depend>
+  <run_depend>python-argparse</run_depend>
+  <run_depend>python-rospkg</run_depend>
+  <run_depend>python_qt_binding</run_depend>
+ 
+  <run_depend>rospy</run_depend>
+  <run_depend>rqt_gui</run_depend>
+  <run_depend>rqt_gui_py</run_depend>
 
   <export>    	
     <rqt_gui plugin="${prefix}/plugin.xml"/>


### PR DESCRIPTION
# Issue
- Missing dependency
   - Looking at http://wiki.ros.org/arni/Tutorials/Setup, I thought I'd run `rosrun arni_nodeinterface arni_nodeinterface` so I added `arni_nodeinterface` in my pkg and built. Then the same command complained `arni_core` pkg was missing, which apparently seems to not in the dependency chain stemming from `arni_nodeinterface`.
- Cyclic dependency

# Changes added
- Added missing dependency.
- (Optional) Prettify formats. Remove boilerplate (all done by roscompile. See [discourse.ros.org#17312](https://discourse.ros.org/t/roscompile-ros-world-lightning-talk/17312)).
